### PR TITLE
Fix cardinality issue on puppetdb_status_node_guage

### DIFF
--- a/puppetdb_exporter.go
+++ b/puppetdb_exporter.go
@@ -690,7 +690,7 @@ func GenerateReportsMetrics(c *puppetdb.Client, nodes bool, debug bool, timeout 
 
 	statusNodesGuage.Reset()
 	for _, entry := range *nodeStatusArr {
-		statusNodesGuage.WithLabelValues(entry.Status, entry.Value, entry.Environment, entry.Certname).Inc()
+		statusNodesGuage.WithLabelValues(entry.Status, entry.Environment, entry.Certname).Set(entry.Value)
 	}
 }
 


### PR DESCRIPTION
Currently it appears that the code is setting a label to the `entry.Value` on the `puppetdb_status_node_guage` metric which will cause it to produce a label for every scrape that this value changes and it appears that it is the time since the last run or something similar as it matches with another metric found in `puppetdb_last_report_time_node_guage`.  

If this fix isn't right, as I'm not 100% clear on what you're trying to do with a metric we at least need to address the cardinality issue that this label creates.  I might be able to create a better fix for you if you help me understand what this metric should return.  Right now it only ever returns a 1 for us but has many different labels and thus time series which will be a problem when it's multiplied out by many servers for a long time.

More on what I mean by the issue of cardinality.
https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels
https://www.robustperception.io/cardinality-is-key